### PR TITLE
upgrade tensorflow to 0.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && apt-get update && apt-get install -y curl dnsutils oracle-java8-installer ca-certificates
 
 
-workdir /root
-run echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-run curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-run apt-get update && apt-get install -y bazel
+# install latest bazel 
+# run echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+# run curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+# run apt-get update && apt-get install -y bazel
 
 run pip install virtualenv
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,20 +2,35 @@ from gliacloud/base_images:django
 
 run apt-get install python-software-properties software-properties-common python-software-properties  -y
 
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && apt-get update && apt-get install -y curl dnsutils oracle-java8-installer ca-certificates
+#RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
+#RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
+#RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+#RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && apt-get update && apt-get install -y curl dnsutils oracle-java8-installer ca-certificates
+
+RUN add-apt-repository -y ppa:openjdk-r/ppa
+RUN apt-get -y update
+RUN apt-get -y install openjdk-8-jdk
+RUN apt-get install -y swig unzip wget
 
 
-# install latest bazel 
-# run echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
-# run curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
-# run apt-get update && apt-get install -y bazel
+RUN apt-get update \
+    && apt-get install git zlib1g-dev file swig python2.7 python-dev python-pip python-mock -y \
+    && pip install --upgrade pip \
+    && pip install -U protobuf==3.0.0b2 \
+    && pip install asciitree \
+    && pip install numpy \
+    && wget https://github.com/bazelbuild/bazel/releases/download/0.4.3/bazel-0.4.3-installer-linux-x86_64.sh \
+    && chmod +x bazel-0.4.3-installer-linux-x86_64.sh \
+    && ./bazel-0.4.3-installer-linux-x86_64.sh \
+    && apt-get autoremove
+
+# install latest bazel
+#run echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+#run curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+#run apt-get update && apt-get install -y bazel
 
 run pip install virtualenv
 
 add . /work
 workdir /work
-run wget https://github.com/bazelbuild/bazel/releases/download/0.4.0/bazel-0.4.0-installer-linux-x86_64.sh && chmod +x bazel-0.4.0-installer-linux-x86_64.sh && ./bazel-0.4.0-installer-linux-x86_64.sh
 run python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+from gliacloud/base_images:django
+
+run apt-get install python-software-properties software-properties-common python-software-properties  -y
+
+RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
+RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list
+RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 && apt-get update && apt-get install -y curl dnsutils oracle-java8-installer ca-certificates
+
+
+workdir /root
+run echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
+run curl https://bazel.build/bazel-release.pub.gpg | apt-key add -
+run apt-get update && apt-get install -y bazel
+
+run pip install virtualenv
+
+add . /work
+run wget https://github.com/bazelbuild/bazel/releases/download/0.4.0/bazel-0.4.0-installer-linux-x86_64.sh && chmod +x bazel-0.4.0-installer-linux-x86_64.sh && ./bazel-0.4.0-installer-linux-x86_64.sh
+workdir /work/syntaxnet_wrapper
+run make

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ run apt-get update && apt-get install -y bazel
 run pip install virtualenv
 
 add . /work
+workdir /work
 run wget https://github.com/bazelbuild/bazel/releases/download/0.4.0/bazel-0.4.0-installer-linux-x86_64.sh && chmod +x bazel-0.4.0-installer-linux-x86_64.sh && ./bazel-0.4.0-installer-linux-x86_64.sh
-workdir /work/syntaxnet_wrapper
-run make
+run python setup.py install

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2016-2017 GliaCloud, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 #### Prerequisites
 
-Install `bazel 0.2.2b`.
+Install `bazel` and include `bazel` in `$PATH`.
 
 ```shell-script
-wget https://github.com/bazelbuild/bazel/releases/download/0.2.2b/bazel-0.2.2b-installer-linux-x86_64.sh
-chmod +x bazel-0.2.2b-installer-linux-x86_64.sh
-./bazel-0.2.2b-installer-linux-x86_64.sh --user
-rm bazel-0.2.2b-installer-linux-x86_64.sh
+wget https://github.com/bazelbuild/bazel/releases/download/0.4.4/bazel-0.4.4-installer-linux-x86_64.sh
+chmod +x bazel-0.4.4-installer-linux-x86_64.sh
+./bazel-0.4.4-installer-linux-x86_64.sh --user
+rm bazel-0.4.4-installer-linux-x86_64.sh
+export PATH="$PATH:$HOME/bin"
 ```
 
 Install OpenJDK8.
@@ -19,6 +20,18 @@ Install OpenJDK8.
 add-apt-repository -y ppa:openjdk-r/ppa
 apt-get -y update
 apt-get -y install openjdk-8-jdk
+```
+
+Install system package dependencies.
+
+```shell-script
+apt-get -y install swig unzip
+```
+
+Install Python packages
+
+```shell-script
+pip install tensorflow protobuf asciitree mock
 ```
 
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class InstallClass(install):
 
 
 setup(name='syntaxnet_wrapper',
-      version='0.3.2',
+      version='0.4.0',
       description='A Python Wrapper for Google SyntaxNet',
       url='https://github.com/livingbio/syntaxnet_wrapper',
       author='Ping Chu Hung',

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import subprocess
 class InstallClass(install):
     def run(self):
         install.run(self)
-        subprocess.call(['pip', 'install', 'tensorflow', 'virtualenv', 'protobuf', 'asciitree', 'mock'])
+        subprocess.call(['pip', 'install', 'tensorflow==0.12.1', 'virtualenv', 'protobuf', 'asciitree', 'mock'])
         sys.path.reverse()
         import syntaxnet_wrapper
         syntaxnet_wrapper_dir = syntaxnet_wrapper.__path__[0]

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from setuptools import setup
 from setuptools.command.install import install
 import sys
@@ -9,13 +10,6 @@ import stat
 import site
 from distutils.sysconfig import get_python_lib
 
-model_list = ['Arabic', 'Basque', 'Bulgarian', 'Catalan', 'Chinese', 'Croatian',
-    'Czech', 'Danish', 'Dutch', 'English', 'Estonian', 'Finnish', 'French',
-    'Galician', 'German', 'Gothic', 'Greek', 'Hebrew', 'Hindi', 'Hungarian',
-    'Indonesian', 'Irish', 'Italian', 'Kazakh', 'Latin', 'Latvian', 'Norwegian',
-    'Persian', 'Polish', 'Portuguese', 'Romanian', 'Russian', 'Slovenian',
-    'Spanish', 'Swedish', 'Tamil', 'Turkish', ]
-
 
 class InstallClass(install):
     def run(self):
@@ -25,30 +19,6 @@ class InstallClass(install):
         syntaxnet_wrapper_dir = syntaxnet_wrapper.__path__[0]
         subprocess.call(['make'], cwd=syntaxnet_wrapper_dir)
 
-
-class InstallTarClass(install):
-    def run(self):
-        pip.main(['install', 'https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.10.0rc0-cp27-none-linux_x86_64.whl'])
-        install.run(self)
-        package_dir = [p for p in sys.path if p.endswith('site-packages')][0]
-        package_dir = path.join(package_dir, 'syntaxnet_wrapper')
-        print 'Start downloading syntaxnet.tgz...'
-        subprocess.call(['wget', '-q', 'https://gliacloud.blob.core.windows.net/nlp/syntaxnet.tgz'], cwd=package_dir)
-        print 'Start extracting syntaxnet.tgz...'
-        subprocess.call(['tar', 'xzf', 'syntaxnet.tgz'], cwd=package_dir)
-        model_dir = path.join(package_dir, 'models/syntaxnet/syntaxnet/models/parsey_universal')
-        model_url = 'http://download.tensorflow.org/models/parsey_universal/{}.zip'
-        print 'Start downloading pretrained models...'
-        for model_name in model_list:
-            subprocess.call(['wget', '-q', model_url.format(model_name)], cwd=model_dir)
-            subprocess.call(['unzip', '-n', '-qq', '{}.zip'.format(model_name)], cwd=model_dir)
-            os.unlink(path.join(model_dir, '{}.zip'.format(model_name)))
-            dir_name = path.join(model_dir, model_name)
-            os.chmod(dir_name, os.stat(dir_name).st_mode | stat.S_IROTH | stat.S_IXOTH)
-            for fn in os.listdir(dir_name):
-                fpath = path.join(dir_name, fn)
-                os.chmod(fpath, os.stat(fpath).st_mode | stat.S_IROTH)
-            print model_name, 'model is installed.'
 
 setup(name='syntaxnet_wrapper',
       version='0.3.2',
@@ -62,10 +32,10 @@ setup(name='syntaxnet_wrapper',
       install_requires=[
           'protobuf==3.0.0b2',
           'asciitree',
+          'mock',
       ],
       cmdclass={
           'install': InstallClass,
-          'install_tar': InstallTarClass,
       },
       test_suite='nose.collector',
       tests_require=['nose'],

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,6 @@ from setuptools import setup
 from setuptools.command.install import install
 import sys
 import subprocess
-from os import path
-import os
-import pip
-import stat
-import site
-from distutils.sysconfig import get_python_lib
 
 
 class InstallClass(install):
@@ -30,7 +24,9 @@ setup(name='syntaxnet_wrapper',
       packages=['syntaxnet_wrapper'],
       zip_safe=False,
       install_requires=[
-          'protobuf==3.0.0b2',
+          'tensorflow',
+          'virtualenv',
+          'protobuf',
           'asciitree',
           'mock',
       ],

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ import subprocess
 class InstallClass(install):
     def run(self):
         install.run(self)
+        subprocess.call(['pip', 'install', 'tensorflow', 'virtualenv', 'protobuf', 'asciitree', 'mock'])
         sys.path.reverse()
         import syntaxnet_wrapper
         syntaxnet_wrapper_dir = syntaxnet_wrapper.__path__[0]

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(name='syntaxnet_wrapper',
       packages=['syntaxnet_wrapper'],
       zip_safe=False,
       install_requires=[
-          'tensorflow',
+          'tensorflow==0.12.1',
           'virtualenv',
           'protobuf',
           'asciitree',

--- a/syntaxnet_wrapper/__init__.py
+++ b/syntaxnet_wrapper/__init__.py
@@ -37,7 +37,7 @@ class SyntaxNetWrapper(object):
     def stop(self):
         self.din.close()
         try:
-            self.process.send_signal(signal.SIGABRT)
+            self.process.send_signal(signal.SIGKILL)
             self.process.kill()
             self.process.wait()
         except OSError:

--- a/syntaxnet_wrapper/__init__.py
+++ b/syntaxnet_wrapper/__init__.py
@@ -49,16 +49,19 @@ class SyntaxNetWrapper(object):
             logger.info(e)
 
     def make_pidfile(self):
+        if not os.path.isdir(PIDFILE_PATH):
+            os.mkdir(PIDFILE_PATH)
         pidfilename = os.path.join(PIDFILE_PATH, "{}.pid".format(self.name))
-        if os.exists(pidfilename):
-            self.kill_process(pidfilename)
-
+        for fn in os.listdir(PIDFILE_PATH):
+            pid, model, clsname = fn.split('_')
+            if clsname == self.__class__.__name__ + '.pid' and model == self.model_name:
+                self.kill_process(fn)
         with open(pidfilename, 'w+') as f:
-            f.write(self.process.pid)
+            f.write(str(self.process.pid))
 
     @property
     def name(self):
-        return u"{}_{}".format(PID, self.__class__.__name__)
+        return u"{}_{}_{}".format(PID, self.model_name, self.__class__.__name__)
 
 
     def start(self):

--- a/syntaxnet_wrapper/__init__.py
+++ b/syntaxnet_wrapper/__init__.py
@@ -21,10 +21,8 @@ class SyntaxNetWrapper(object):
         self.stop()
 
     def start(self):
-        rundir = join(
-            pwd, 'models/syntaxnet/bazel-bin/syntaxnet/parser_eval.runfiles')
-        command = ['python', self.run_filename,
-                   self.model_path, self.context_path]
+        rundir = join(pwd, 'models/syntaxnet/bazel-bin/syntaxnet/parser_eval.runfiles/__main__')
+        command = ['python', self.run_filename, self.model_path, self.context_path]
 
         env = os.environ.copy()
         env['PYTHONPATH'] = rundir
@@ -34,8 +32,7 @@ class SyntaxNetWrapper(object):
         self.process = subprocess.Popen(command, shell=False, **subproc_args)
         self.out = self.process.stdout
         self.din = self.process.stdin
-        fcntl(self.out.fileno(), F_SETFL, fcntl(
-            self.out.fileno(), F_GETFD) | os.O_NONBLOCK)
+        fcntl(self.out.fileno(), F_SETFL, fcntl(self.out.fileno(), F_GETFD) | os.O_NONBLOCK)
 
     def stop(self):
         self.din.close()
@@ -58,8 +55,7 @@ class SyntaxNetWrapper(object):
             model_path = 'models/syntaxnet/syntaxnet/models/parsey_universal/Chinese'
             context_path = 'models/syntaxnet/syntaxnet/models/parsey_universal/context-tokenize-zh.pbtxt'
         else:
-            model_path = 'models/syntaxnet/syntaxnet/models/parsey_universal/{!s}'.format(
-                model_name)
+            model_path = 'models/syntaxnet/syntaxnet/models/parsey_universal/{!s}'.format(model_name)
             context_path = 'models/syntaxnet/syntaxnet/models/parsey_universal/context.pbtxt'
 
         context_path = join(pwd, context_path)
@@ -117,8 +113,7 @@ class SyntaxNetWrapper(object):
 
     def list_models(self):
         pwd = dirname(abspath(__file__))
-        model_path = os.path.join(
-            pwd, 'models/syntaxnet/syntaxnet/models/parsey_universal')
+        model_path = os.path.join(pwd, 'models/syntaxnet/syntaxnet/models/parsey_universal')
         files = os.listdir(model_path)
         models = []
         for fn in files:
@@ -131,8 +126,7 @@ class SyntaxNetWrapper(object):
 class SyntaxNetTokenizer(SyntaxNetWrapper):
 
     def __init__(self, model_name='ZHTokenizer'):
-        super(SyntaxNetTokenizer, self).__init__(
-            'tokenizer_eval_forever.py', model_name)
+        super(SyntaxNetTokenizer, self).__init__('tokenizer_eval_forever.py', model_name)
 
     def query(self, text):
         return super(SyntaxNetTokenizer, self).query(text, returnRaw=True)
@@ -145,8 +139,7 @@ class SyntaxNetMorpher(SyntaxNetWrapper):
             self.tokenizer = SyntaxNetTokenizer()
         else:
             self.tokenizer = None
-        super(SyntaxNetMorpher, self).__init__(
-            'morpher_eval_forever.py', model_name)
+        super(SyntaxNetMorpher, self).__init__('morpher_eval_forever.py', model_name)
 
     def query(self, text, returnRaw=False):
         if self.tokenizer:
@@ -168,8 +161,7 @@ class SyntaxNetTagger(SyntaxNetWrapper):
             self.morpher = kwargs['morpher']
         else:
             self.morpher = SyntaxNetMorpher(model_name)
-        super(SyntaxNetTagger, self).__init__(
-            'tagger_eval_forever.py', model_name)
+        super(SyntaxNetTagger, self).__init__('tagger_eval_forever.py', model_name)
 
     def query(self, morphed_text, returnRaw=False):
         if self.morpher:
@@ -196,8 +188,7 @@ class SyntaxNetParser(SyntaxNetWrapper):
             else:
                 self.morpher = SyntaxNetMorpher(model_name)
             self.tagger = SyntaxNetTagger(model_name, morpher=self.morpher)
-        super(SyntaxNetParser, self).__init__(
-            'parser_eval_forever.py', model_name)
+        super(SyntaxNetParser, self).__init__('parser_eval_forever.py', model_name)
 
     def query(self, text, returnRaw=False):
         conll_text = self.tagger.query(text, returnRaw=True)

--- a/syntaxnet_wrapper/__init__.py
+++ b/syntaxnet_wrapper/__init__.py
@@ -64,7 +64,7 @@ class SyntaxNetWrapper(object):
 
     @property
     def name(self):
-        return u"{}_{}_{}".format(self.process.pid, self.model_name, self.__class__.__name__)
+        return u"{}_{}_{}".format(os.getpid(), self.model_name, self.__class__.__name__)
 
 
     def start(self):

--- a/syntaxnet_wrapper/__init__.py
+++ b/syntaxnet_wrapper/__init__.py
@@ -37,6 +37,7 @@ class SyntaxNetWrapper(object):
     def stop(self):
         self.din.close()
         try:
+            os.kill(self.process.pid, signal.SIGKILL)
             self.process.send_signal(signal.SIGKILL)
             self.process.kill()
             self.process.wait()

--- a/syntaxnet_wrapper/install.sh
+++ b/syntaxnet_wrapper/install.sh
@@ -1,25 +1,16 @@
 #!/bin/sh
 
-#
-# Install bazel 0.2.2b
-#
-wget https://github.com/bazelbuild/bazel/releases/download/0.2.2b/bazel-0.2.2b-installer-linux-x86_64.sh
-chmod +x bazel-0.2.2b-installer-linux-x86_64.sh
-./bazel-0.2.2b-installer-linux-x86_64.sh --user
-rm bazel-0.2.2b-installer-linux-x86_64.sh
+# python package dependencies
+# option-1: you have root permissions
+# option-2: you are inside virtual environment
+pip install tensorflow protobuf asciitree mock
 
 #
 # SyntaxNet original version (installed as a normal user)
 #
-export TF_BINARY_URL=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-0.10.0rc0-cp27-none-linux_x86_64.whl
-sudo pip install --upgrade $TF_BINARY_URL
-sudo apt-get -y install swig unzip
-sudo pip install -U protobuf==3.0.0b2
-sudo pip install asciitree
-###
 git clone --recursive https://github.com/tensorflow/models.git
 cd models/syntaxnet/tensorflow
-./configure < /dev/null  # no Google Cloud Platform support, no GPU support
+printf '\n\n\n\n\n\n' | ./configure  # input everything as default
 cd ..
 ~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/...
 # The --output_user_root ensures that all of the build output is

--- a/syntaxnet_wrapper/makefile
+++ b/syntaxnet_wrapper/makefile
@@ -1,5 +1,40 @@
+all: download_language_models
 
-all: models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek-PROIEL \
+configure_syntaxnet:
+	echo "************************************************************"
+	echo "                  configure syntaxnet                       "
+	echo "************************************************************"
+	git clone --recursive https://github.com/tensorflow/models.git && \
+	cd models/syntaxnet/tensorflow && \
+	virtualenv /tmp/venv && \
+	/tmp/venv/bin/pip install tensorflow && \
+	printf '/tmp/venv/bin/python\n\n\n\n\n\n' | ./configure
+
+build_syntaxnet: configure_syntaxnet
+	echo "************************************************************"
+	echo "                     build syntaxnet                        "
+	echo "************************************************************"
+	cd models/syntaxnet && \
+	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
+	rm -rf bazel_root
+	rm tensorflow/util/python/python_lib
+	ln -s `python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` tensorflow/util/python/python_lib
+	echo "************************************************************"
+	echo "                building syntaxnet finished                 "
+	echo "************************************************************"
+
+copy_demo_scripts: build_syntaxnet
+	cp models/syntaxnet/syntaxnet/models/parsey_universal/parse.sh models/syntaxnet/parse.sh
+	cp models/syntaxnet/syntaxnet/models/parsey_universal/tokenize.sh models/syntaxnet/tokenize.sh
+	cp models/syntaxnet/syntaxnet/models/parsey_universal/tokenize_zh.sh models/syntaxnet/tokenize_zh.sh
+
+clear_tmp_venv: copy_demo_scripts
+	rm -rf /tmp/venv
+	echo "************************************************************"
+	echo "                 download language models                   "
+	echo "************************************************************"
+
+download_language_models: models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek-PROIEL \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Arabic \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Basque \
@@ -52,26 +87,7 @@ all: models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek-PROIEL \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Tamil \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Turkish
 
-models:
-	git clone --recursive https://github.com/tensorflow/models.git && \
-	cd models/syntaxnet/tensorflow && \
-	printf '/usr/local/lib/python2.7.12/bin/python\n\n\n\n\n\n' | ./configure
-
-models/syntaxnet/bazel_root: models
-	cd models/syntaxnet && \
-	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
-	rm -rf bazel_root
-
-models/syntaxnet/parse.sh: models
-	cp models/syntaxnet/syntaxnet/models/parsey_universal/parse.sh models/syntaxnet/parse.sh
-
-models/syntaxnet/tokenize.sh: models
-	cp models/syntaxnet/syntaxnet/models/parsey_universal/tokenize.sh models/syntaxnet/tokenize.sh
-
-models/syntaxnet/tokenize_zh.sh: models
-	cp models/syntaxnet/syntaxnet/models/parsey_universal/tokenize_zh.sh models/syntaxnet/tokenize_zh.sh
-
-models/syntaxnet/syntaxnet/models/parsey_universal/%: models/syntaxnet/bazel_root models/syntaxnet/parse.sh models/syntaxnet/tokenize.sh models/syntaxnet/tokenize_zh.sh
+models/syntaxnet/syntaxnet/models/parsey_universal/%: clear_tmp_venv
 	cd models/syntaxnet/syntaxnet/models/parsey_universal/ && \
 	wget http://download.tensorflow.org/models/parsey_universal/$*.zip && \
 	unzip $*.zip && \

--- a/syntaxnet_wrapper/makefile
+++ b/syntaxnet_wrapper/makefile
@@ -52,18 +52,14 @@ all: models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek-PROIEL \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Tamil \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Turkish
 
-models: 
+models:
 	git clone --recursive https://github.com/tensorflow/models.git && \
-	cd models && \
-	git checkout f98c5ded31d7da0c2d127c28b2c16f0307a368f0 && \
-	git submodule update && \
-	cd syntaxnet/tensorflow && \
-	git clean -fd && \
-	./configure < /dev/null 
+	cd models/syntaxnet/tensorflow && \
+	printf '/usr/local/lib/python2.7.12/bin/python\n\n\n\n\n\n' | ./configure
 
 models/syntaxnet/bazel_root: models
 	cd models/syntaxnet && \
-    	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
+	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
 	rm -rf bazel_root
 
 models/syntaxnet/parse.sh: models
@@ -77,8 +73,6 @@ models/syntaxnet/tokenize_zh.sh: models
 
 models/syntaxnet/syntaxnet/models/parsey_universal/%: models/syntaxnet/bazel_root models/syntaxnet/parse.sh models/syntaxnet/tokenize.sh models/syntaxnet/tokenize_zh.sh
 	cd models/syntaxnet/syntaxnet/models/parsey_universal/ && \
-    	wget http://download.tensorflow.org/models/parsey_universal/$*.zip && \
-    	unzip $*.zip && \
-    	rm $*.zip
-
-
+	wget http://download.tensorflow.org/models/parsey_universal/$*.zip && \
+	unzip $*.zip && \
+	rm $*.zip

--- a/syntaxnet_wrapper/makefile
+++ b/syntaxnet_wrapper/makefile
@@ -15,7 +15,7 @@ build_syntaxnet: configure_syntaxnet
 	@echo "                     build syntaxnet                        " 1>&2
 	@echo "************************************************************" 1>&2
 	cd models/syntaxnet && \
-	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
+	bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
 	rm -rf bazel_root
 	cd models/syntaxnet && \
 	rm tensorflow/util/python/python_lib && \

--- a/syntaxnet_wrapper/makefile
+++ b/syntaxnet_wrapper/makefile
@@ -7,7 +7,7 @@ configure_syntaxnet:
 	git clone --recursive https://github.com/tensorflow/models.git && \
 	cd models/syntaxnet/tensorflow && \
 	virtualenv /tmp/venv && \
-	/tmp/venv/bin/pip install tensorflow && \
+	/tmp/venv/bin/pip install tensorflow==0.12.1 && \
 	printf '/tmp/venv/bin/python\n\n\n\n\n\n' | ./configure
 
 build_syntaxnet: configure_syntaxnet

--- a/syntaxnet_wrapper/makefile
+++ b/syntaxnet_wrapper/makefile
@@ -1,9 +1,9 @@
 all: download_language_models
 
 configure_syntaxnet:
-	echo "************************************************************"
-	echo "                  configure syntaxnet                       "
-	echo "************************************************************"
+	@echo "************************************************************" 1>&2
+	@echo "                  configure syntaxnet                       " 1>&2
+	@echo "************************************************************" 1>&2
 	git clone --recursive https://github.com/tensorflow/models.git && \
 	cd models/syntaxnet/tensorflow && \
 	virtualenv /tmp/venv && \
@@ -11,17 +11,18 @@ configure_syntaxnet:
 	printf '/tmp/venv/bin/python\n\n\n\n\n\n' | ./configure
 
 build_syntaxnet: configure_syntaxnet
-	echo "************************************************************"
-	echo "                     build syntaxnet                        "
-	echo "************************************************************"
+	@echo "************************************************************" 1>&2
+	@echo "                     build syntaxnet                        " 1>&2
+	@echo "************************************************************" 1>&2
 	cd models/syntaxnet && \
 	~/bin/bazel --output_user_root=bazel_root test syntaxnet/... util/utf8/... || \
 	rm -rf bazel_root
-	rm tensorflow/util/python/python_lib
+	cd models/syntaxnet && \
+	rm tensorflow/util/python/python_lib && \
 	ln -s `python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())"` tensorflow/util/python/python_lib
-	echo "************************************************************"
-	echo "                building syntaxnet finished                 "
-	echo "************************************************************"
+	@echo "************************************************************" 1>&2
+	@echo "                building syntaxnet finished                 " 1>&2
+	@echo "************************************************************" 1>&2
 
 copy_demo_scripts: build_syntaxnet
 	cp models/syntaxnet/syntaxnet/models/parsey_universal/parse.sh models/syntaxnet/parse.sh
@@ -30,9 +31,9 @@ copy_demo_scripts: build_syntaxnet
 
 clear_tmp_venv: copy_demo_scripts
 	rm -rf /tmp/venv
-	echo "************************************************************"
-	echo "                 download language models                   "
-	echo "************************************************************"
+	@echo "************************************************************" 1>&2
+	@echo "                 download language models                   " 1>&2
+	@echo "************************************************************" 1>&2
 
 download_language_models: models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek-PROIEL \
 	models/syntaxnet/syntaxnet/models/parsey_universal/Ancient_Greek \

--- a/syntaxnet_wrapper/parser_eval_forever.py
+++ b/syntaxnet_wrapper/parser_eval_forever.py
@@ -93,4 +93,5 @@ signal.signal(signal.SIGABRT, abort_handler)
 while True:
     sys.stdout.write('\n## input content:\n')
     sys.stdout.flush()
+    signal.alarm(1800)
     signal.pause()

--- a/syntaxnet_wrapper/tagger_eval_forever.py
+++ b/syntaxnet_wrapper/tagger_eval_forever.py
@@ -95,4 +95,5 @@ signal.signal(signal.SIGABRT, abort_handler)
 while True:
     sys.stdout.write('\n## input content:\n')
     sys.stdout.flush()
+    signal.alarm(1800)
     signal.pause()

--- a/syntaxnet_wrapper/tokenizer_eval_forever.py
+++ b/syntaxnet_wrapper/tokenizer_eval_forever.py
@@ -89,4 +89,5 @@ signal.signal(signal.SIGABRT, abort_handler)
 while True:
     sys.stdout.write('\n## input content:\n')
     sys.stdout.flush()
+    signal.alarm(1800)
     signal.pause()


### PR DESCRIPTION
fix #15 
fix #16
fix #17 

已知問題：
1. https://github.com/livingbio/syntaxnet_wrapper/blob/upgrade-tensorflow/syntaxnet_wrapper/makefile#L58
    這裡必需輸入一個與當前環境不同的python路徑
    如果當前環境是virtualenv，就輸入global的python
    問題是這裡的路徑太過死板，如果未來升級到python 2.7.13就無法使用
2. https://github.com/livingbio/syntaxnet_wrapper/blob/upgrade-tensorflow/syntaxnet_wrapper/__init__.py#L40
    `signal.SIGABRT` 無法成功刪除process，導致主程式離開後，subprocess還在